### PR TITLE
build(deps): use non-fastjson SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <slf4j.version>1.7.15</slf4j.version>
         <logback.version>1.2.3</logback.version>
         <guava.version>27.0-jre</guava.version>
-        <aliyun-log.version>0.6.149</aliyun-log.version>
+        <aliyun-log.version>0.6.161-non-fastjson.1</aliyun-log.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary

- Upgrade `com.aliyun.openservices:aliyun-log` from `0.6.149` to `0.6.161-non-fastjson.1`.
- Remove the Producer's transitive dependency on fastjson.
- Pick up Apache HttpClient 5.3.1 through the updated SDK.

## Compatibility

The Producer does not directly use fastjson APIs, so no Producer source changes are required.

## Verification

- 35 environment-independent unit tests passed
- Maven package build passed
- Dependency tree resolves `aliyun-log:0.6.161-non-fastjson.1` and HttpClient 5.3.1
- Dependency tree contains no fastjson artifact