### PR TITLE
build: bump version to 0.3.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.aliyun.openservices</groupId>
     <artifactId>aliyun-log-producer</artifactId>
-    <version>0.3.29</version>
+    <version>0.3.30</version>
 
     <name>Aliyun LOG Java Producer</name>
     <url>https://aliyun.com/product/sls</url>


### PR DESCRIPTION
## Summary

- Bump the Producer release version from `0.3.29` to `0.3.30`.
- Keep the SDK dependency at `0.6.161-non-fastjson.1`.

## Verification

- Maven project version resolves to `0.3.30`
- 35 environment-independent unit tests passed
- Maven package build passed
- Regular and fat JAR artifacts generated for version `0.3.30`